### PR TITLE
Remove posts as admin

### DIFF
--- a/public/feed.php
+++ b/public/feed.php
@@ -93,7 +93,7 @@ LoadProfileData($_SESSION['user']['id']);
                     <hr/>
 
                     <?php
-                    $stmt = $conn->prepare("SELECT u.id ,u.email ,u.firstname ,u.lastname ,po.id ,po.date ,po.user_id ,po.likes ,po.content ,pr.profile_picture ,pr.intro FROM user u INNER JOIN post po on u.id = po.user_id INNER JOIN profiles pr on po.user_id = pr.user_id ORDER BY po.id DESC");
+                    $stmt = $conn->prepare("SELECT u.id ,u.email ,u.firstname ,u.lastname, u.admin ,po.id ,po.date ,po.user_id ,po.likes ,po.content ,pr.profile_picture ,pr.intro FROM user u INNER JOIN post po on u.id = po.user_id INNER JOIN profiles pr on po.user_id = pr.user_id ORDER BY po.id DESC");
                     $stmt->execute();
                     $result = $stmt->get_result();
 
@@ -133,7 +133,9 @@ LoadProfileData($_SESSION['user']['id']);
                                                 </span>
                                             </a>
                                         </div>
-                                        <?php if ($row['user_id'] == $_SESSION['user']['id']) { ?>
+                                        <?php
+                                        //Display the delete button if the user is the owner or if the loggedin user is an admin
+                                        if ($row['user_id'] == $_SESSION['user']['id'] || $_SESSION['user']['admin'] == 1) { ?>
                                             <div class="level-right">
                                                 <a class="level-item">
 													<form action="includes/deletepost.inc.php" method="POST">


### PR DESCRIPTION
Admins are now able to remove other users their posts, before only the post owner could remove it. This has been solved now.